### PR TITLE
Add neon-styled snake game

### DIFF
--- a/snake/index.html
+++ b/snake/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Serpent — 终极贪吃蛇</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="stars"></div>
+  <div class="aurora"></div>
+  <main class="game-wrapper">
+    <header class="top-bar">
+      <div class="branding">
+        <h1>Neon Serpent</h1>
+        <p>世界上最炫丽的贪吃蛇，响应式音效、动态光影与粒子效果</p>
+      </div>
+      <aside class="meta">
+        <button id="themeToggle" class="glass-button" type="button" aria-label="切换主题">🌗</button>
+        <div class="badges">
+          <span class="badge">速度 X<span id="speedBadge">1</span></span>
+          <span class="badge">长度 <span id="lengthBadge">5</span></span>
+        </div>
+      </aside>
+    </header>
+
+    <section class="stats">
+      <div class="stat">
+        <span class="label">得分</span>
+        <span id="score" class="value">0</span>
+      </div>
+      <div class="stat">
+        <span class="label">最高分</span>
+        <span id="best" class="value">0</span>
+      </div>
+      <div class="stat">
+        <span class="label">关卡</span>
+        <div class="progress">
+          <div id="levelProgress" class="progress-bar"></div>
+        </div>
+        <span id="level" class="value">1</span>
+      </div>
+      <div class="stat">
+        <span class="label">节奏</span>
+        <span id="tempo" class="value">温和</span>
+      </div>
+    </section>
+
+    <section class="canvas-container">
+      <canvas id="gameCanvas" width="640" height="640" role="img" aria-label="贪吃蛇游戏画布"></canvas>
+      <div class="canvas-glow"></div>
+      <div id="overlay" class="overlay">
+        <div class="overlay-content">
+          <h2>准备好起舞了吗？</h2>
+          <p>使用 <strong>方向键/WASD</strong> 或 <strong>轻触按钮</strong> 控制蛇蛇。
+            收集多彩能量果实，避开自己，尽情欣赏光影流动。</p>
+          <button id="startButton" class="glass-button">点击开始</button>
+        </div>
+      </div>
+      <div class="touch-controls">
+        <button class="control" data-dir="up" aria-label="向上">▲</button>
+        <div class="middle-row">
+          <button class="control" data-dir="left" aria-label="向左">◀</button>
+          <button class="control" data-dir="down" aria-label="向下">▼</button>
+          <button class="control" data-dir="right" aria-label="向右">▶</button>
+        </div>
+      </div>
+    </section>
+
+    <footer class="info">
+      <p>支持 <strong>键盘</strong> 与 <strong>触屏</strong>，吃掉不同颜色的能量果实可触发独特效果。</p>
+      <ul>
+        <li><span class="dot dot--berry"></span> 甜浆果：+10 分</li>
+        <li><span class="dot dot--citrus"></span> 阳光橙：+25 分，速度+10%</li>
+        <li><span class="dot dot--mint"></span> 冰薄荷：慢动作 3 秒</li>
+        <li><span class="dot dot--royal"></span> 皇室星辰：+50 分，身形变幻</li>
+      </ul>
+      <p class="credit">设计 &amp; 开发：你的虚拟助手 — 愿你沉浸在霓虹之夜。</p>
+    </footer>
+  </main>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/snake/main.js
+++ b/snake/main.js
@@ -1,0 +1,845 @@
+const canvas = document.getElementById("gameCanvas");
+const ctx = canvas.getContext("2d");
+
+const overlay = document.getElementById("overlay");
+const overlayTitle = overlay.querySelector("h2");
+const overlayMessage = overlay.querySelector("p");
+const overlayButton = document.getElementById("startButton");
+const overlayInitial = {
+  title: overlayTitle.textContent,
+  message: overlayMessage.innerHTML,
+  button: overlayButton.textContent,
+};
+
+const scoreEl = document.getElementById("score");
+const bestEl = document.getElementById("best");
+const levelEl = document.getElementById("level");
+const tempoEl = document.getElementById("tempo");
+const speedBadgeEl = document.getElementById("speedBadge");
+const lengthBadgeEl = document.getElementById("lengthBadge");
+const levelProgressEl = document.getElementById("levelProgress");
+
+const statsCards = Array.from(document.querySelectorAll(".stats .stat"));
+const scoreCard = statsCards[0];
+const bestCard = statsCards[1];
+const levelCard = statsCards[2];
+const tempoCard = statsCards[3];
+
+const themeToggle = document.getElementById("themeToggle");
+const touchButtons = Array.from(document.querySelectorAll(".touch-controls .control"));
+
+const config = {
+  gridSize: 32,
+  tileSize: canvas.width / 32,
+  baseSpeed: 150,
+  minInterval: 50,
+  levelSpan: 120,
+  minFood: 2,
+};
+
+const foodTypes = [
+  {
+    key: "berry",
+    label: "甜浆果",
+    color: "#ff6b81",
+    particles: "#ff8fa3",
+    score: 10,
+    growth: 1,
+    weight: 6,
+  },
+  {
+    key: "citrus",
+    label: "阳光橙",
+    color: "#ffb347",
+    particles: "#ffd077",
+    score: 25,
+    growth: 1,
+    weight: 3,
+    onEat: () => {
+      speedBonus = Math.min(speedBonus + 0.18, 0.55);
+      createFloatingText("节奏加快", "#ffb347");
+      triggerPulse(tempoCard);
+    },
+  },
+  {
+    key: "mint",
+    label: "冰薄荷",
+    color: "#6cf9e5",
+    particles: "#a8fff2",
+    score: 18,
+    growth: 2,
+    weight: 2,
+    onEat: () => {
+      slowTimer = 3200;
+      createFloatingText("慢动作", "#6cf9e5");
+      triggerPulse(tempoCard);
+    },
+  },
+  {
+    key: "royal",
+    label: "皇室星辰",
+    color: "#c77dff",
+    particles: "#e7c2ff",
+    score: 50,
+    growth: 3,
+    weight: 1,
+    onEat: () => {
+      rainbowTimer = 8000;
+      createFloatingText("霓虹觉醒", "#c77dff");
+      triggerPulse(tempoCard);
+    },
+  },
+];
+
+const tempoLabels = [
+  { threshold: 1.15, label: "温和" },
+  { threshold: 1.3, label: "灵动" },
+  { threshold: 1.5, label: "燃烧" },
+  { threshold: 1.75, label: "狂热" },
+  { threshold: Infinity, label: "光速" },
+];
+
+const THEME_KEY = "neon-serpent-theme";
+const BEST_KEY = "neon-serpent-best";
+
+class AudioManager {
+  constructor() {
+    this.ctx = null;
+    this.enabled = !!(window.AudioContext || window.webkitAudioContext);
+  }
+
+  init() {
+    if (!this.enabled || this.ctx) return;
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    try {
+      this.ctx = new Ctx();
+    } catch (err) {
+      this.enabled = false;
+    }
+  }
+
+  resume() {
+    if (!this.ctx || this.ctx.state === "running") return;
+    this.ctx.resume().catch(() => {});
+  }
+
+  play(frequency, type = "sine", duration = 0.28, gainValue = 0.1) {
+    if (!this.ctx || this.ctx.state !== "running") return;
+    const osc = this.ctx.createOscillator();
+    const gain = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(frequency, this.ctx.currentTime);
+    gain.gain.setValueAtTime(gainValue, this.ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.0001, this.ctx.currentTime + duration);
+    osc.connect(gain);
+    gain.connect(this.ctx.destination);
+    osc.start();
+    osc.stop(this.ctx.currentTime + duration);
+  }
+
+  playPair(frequencies, type = "sine", duration = 0.32, gainValue = 0.08) {
+    frequencies.forEach((freq, index) => {
+      setTimeout(() => {
+        this.play(freq, type, duration, gainValue);
+      }, index * 40);
+    });
+  }
+
+  onStart() {
+    this.playPair([220, 330, 440], "triangle", 0.35, 0.08);
+  }
+
+  onFruit(typeKey) {
+    const tones = {
+      berry: 260,
+      citrus: 330,
+      mint: 210,
+      royal: 480,
+    };
+    this.playPair([tones[typeKey] || 260, (tones[typeKey] || 260) * 2], "sine", 0.25, 0.08);
+  }
+
+  onLevelUp() {
+    this.playPair([420, 560, 720], "triangle", 0.38, 0.1);
+  }
+
+  onGameOver() {
+    this.playPair([320, 180], "sawtooth", 0.45, 0.08);
+  }
+}
+
+const audio = new AudioManager();
+
+let snake = [];
+let pendingDirection = null;
+let direction = { x: 1, y: 0 };
+let foods = [];
+let particles = [];
+let ripples = [];
+let floatingTexts = [];
+let growth = 0;
+let score = 0;
+let bestScore = Number(localStorage.getItem(BEST_KEY)) || 0;
+let level = 1;
+let speedBonus = 0;
+let slowTimer = 0;
+let rainbowTimer = 0;
+let rainbowHue = 200;
+let state = "idle";
+let lastFrameTime = 0;
+let lastStepTime = 0;
+let touchStartPoint = null;
+
+bestEl.textContent = bestScore;
+
+const initialSnakeLength = 5;
+
+function startGame() {
+  audio.init();
+  audio.resume();
+  audio.onStart();
+
+  state = "running";
+  overlay.classList.add("hidden");
+  overlayTitle.textContent = overlayInitial.title;
+  overlayMessage.innerHTML = overlayInitial.message;
+  overlayButton.textContent = overlayInitial.button;
+
+  const startX = Math.floor(config.gridSize / 2);
+  const startY = Math.floor(config.gridSize / 2);
+  snake = Array.from({ length: initialSnakeLength }, (_, i) => ({
+    x: startX - i,
+    y: startY,
+  }));
+  direction = { x: 1, y: 0 };
+  pendingDirection = null;
+  growth = 0;
+  score = 0;
+  level = 1;
+  speedBonus = 0;
+  slowTimer = 0;
+  rainbowTimer = 0;
+  particles = [];
+  ripples = [];
+  floatingTexts = [];
+  foods = [];
+  ensureFood();
+  updateScoreboard();
+  const now = performance.now();
+  lastFrameTime = now;
+  lastStepTime = now;
+}
+
+function endGame() {
+  state = "gameover";
+  audio.onGameOver();
+  overlay.classList.remove("hidden");
+  overlayTitle.textContent = "霓虹终曲";
+  const recordText = score > bestScore ? "✨ 新纪录诞生！" : "继续挑战，点燃节奏。";
+  overlayMessage.innerHTML = `本次得分 <strong>${score}</strong> 分。<br>${recordText}`;
+  overlayButton.textContent = "再战一曲";
+}
+
+function ensureFood() {
+  while (foods.length < config.minFood) {
+    const food = createFood();
+    if (!food) {
+      break;
+    }
+    foods.push(food);
+  }
+}
+
+function createFood() {
+  const availableCells = new Set();
+  for (let y = 0; y < config.gridSize; y += 1) {
+    for (let x = 0; x < config.gridSize; x += 1) {
+      availableCells.add(`${x},${y}`);
+    }
+  }
+  snake.forEach((segment) => {
+    availableCells.delete(`${segment.x},${segment.y}`);
+  });
+  foods.forEach((food) => {
+    availableCells.delete(`${food.x},${food.y}`);
+  });
+
+  if (!availableCells.size) {
+    return null;
+  }
+
+  const cells = Array.from(availableCells);
+  const index = Math.floor(Math.random() * cells.length);
+  const [x, y] = cells[index].split(",").map(Number);
+
+  const type = pickFoodType();
+  return {
+    x,
+    y,
+    type,
+    createdAt: performance.now(),
+    waveOffset: Math.random() * Math.PI * 2,
+  };
+}
+
+function pickFoodType() {
+  const total = foodTypes.reduce((sum, item) => sum + item.weight, 0);
+  let roll = Math.random() * total;
+  for (const type of foodTypes) {
+    if (roll < type.weight) {
+      return type;
+    }
+    roll -= type.weight;
+  }
+  return foodTypes[0];
+}
+
+function hexToRgba(hex, alpha = 1) {
+  const parsed = hex.replace("#", "");
+  const bigint = parseInt(parsed, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function triggerPulse(card) {
+  if (!card) return;
+  card.classList.remove("pulse");
+  card.offsetHeight;
+  card.classList.add("pulse");
+}
+
+function addScore(amount) {
+  score += amount;
+  if (score > bestScore) {
+    bestScore = score;
+    bestEl.textContent = bestScore;
+    localStorage.setItem(BEST_KEY, bestScore.toString());
+    triggerPulse(bestCard);
+  }
+
+  const newLevel = Math.floor(score / config.levelSpan) + 1;
+  if (newLevel !== level) {
+    level = newLevel;
+    triggerPulse(levelCard);
+    audio.onLevelUp();
+    createFloatingText(`升级至 Lv.${level}`, "#7a5cf4");
+  }
+  updateScoreboard();
+  triggerPulse(scoreCard);
+}
+
+function updateScoreboard() {
+  scoreEl.textContent = score;
+  bestEl.textContent = bestScore;
+  levelEl.textContent = level;
+  lengthBadgeEl.textContent = snake.length;
+
+  const baseMultiplier = 1 + (level - 1) * 0.1;
+  const effectiveMultiplier = Math.max(1, baseMultiplier + speedBonus);
+  const tempoLabel = tempoLabels.find((item) => effectiveMultiplier < item.threshold)?.label || "温和";
+  tempoEl.textContent = slowTimer > 0 ? "慢动作" : tempoLabel;
+  speedBadgeEl.textContent = effectiveMultiplier.toFixed(2).replace(/\.00$/, "");
+
+  const progress = ((score % config.levelSpan) / config.levelSpan) * 100;
+  levelProgressEl.style.width = `${Math.min(progress + 2, 100)}%`;
+  levelProgressEl.style.transform = `scaleX(${0.92 + progress / 300})`;
+}
+
+function handleInput(directionVector) {
+  if (state === "idle") {
+    startGame();
+  }
+  if (state !== "running") return;
+  const isOpposite =
+    directionVector.x === -direction.x && directionVector.y === -direction.y;
+  if (isOpposite) return;
+  pendingDirection = directionVector;
+}
+
+const keyBindings = {
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+  KeyW: { x: 0, y: -1 },
+  KeyS: { x: 0, y: 1 },
+  KeyA: { x: -1, y: 0 },
+  KeyD: { x: 1, y: 0 },
+  KeyI: { x: 0, y: -1 },
+  KeyK: { x: 0, y: 1 },
+  KeyJ: { x: -1, y: 0 },
+  KeyL: { x: 1, y: 0 },
+};
+
+document.addEventListener("keydown", (event) => {
+  if (event.code === "Space" && state !== "running") {
+    startGame();
+    return;
+  }
+  const dir = keyBindings[event.code];
+  if (dir) {
+    event.preventDefault();
+    handleInput(dir);
+  }
+});
+
+touchButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const dir = button.dataset.dir;
+    const vector =
+      dir === "up"
+        ? { x: 0, y: -1 }
+        : dir === "down"
+        ? { x: 0, y: 1 }
+        : dir === "left"
+        ? { x: -1, y: 0 }
+        : { x: 1, y: 0 };
+    handleInput(vector);
+  });
+});
+
+canvas.addEventListener(
+  "touchstart",
+  (event) => {
+    if (event.touches.length > 0) {
+      const touch = event.touches[0];
+      touchStartPoint = { x: touch.clientX, y: touch.clientY };
+    }
+  },
+  { passive: true },
+);
+
+canvas.addEventListener(
+  "touchmove",
+  (event) => {
+    if (event.touches.length > 0) {
+      event.preventDefault();
+    }
+  },
+  { passive: false },
+);
+
+canvas.addEventListener(
+  "touchend",
+  (event) => {
+    if (!touchStartPoint || event.changedTouches.length === 0) return;
+    const touch = event.changedTouches[0];
+    const dx = touch.clientX - touchStartPoint.x;
+    const dy = touch.clientY - touchStartPoint.y;
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
+    if (Math.max(absX, absY) < 20) {
+      touchStartPoint = null;
+      return;
+    }
+    if (absX > absY) {
+      handleInput({ x: dx > 0 ? 1 : -1, y: 0 });
+    } else {
+      handleInput({ x: 0, y: dy > 0 ? 1 : -1 });
+    }
+    touchStartPoint = null;
+  },
+  { passive: true },
+);
+
+canvas.addEventListener(
+  "touchcancel",
+  () => {
+    touchStartPoint = null;
+  },
+  { passive: true },
+);
+
+overlayButton.addEventListener("click", () => {
+  if (state === "running") return;
+  startGame();
+});
+
+overlay.addEventListener("click", (event) => {
+  if (event.target === overlay && state !== "running") {
+    startGame();
+  }
+});
+
+const root = document.documentElement;
+const savedTheme = localStorage.getItem(THEME_KEY);
+if (savedTheme === "light") {
+  root.classList.add("light-mode");
+  themeToggle.textContent = "🌞";
+}
+
+themeToggle.addEventListener("click", () => {
+  root.classList.toggle("light-mode");
+  const isLight = root.classList.contains("light-mode");
+  themeToggle.textContent = isLight ? "🌞" : "🌗";
+  localStorage.setItem(THEME_KEY, isLight ? "light" : "dark");
+});
+
+function getStepInterval() {
+  const baseMultiplier = 1 + (level - 1) * 0.1;
+  const effectiveMultiplier = Math.max(1, baseMultiplier + speedBonus);
+  const slowFactor = slowTimer > 0 ? 0.6 : 1;
+  return Math.max(config.minInterval, config.baseSpeed / (effectiveMultiplier * slowFactor));
+}
+
+function step() {
+  if (pendingDirection) {
+    direction = pendingDirection;
+    pendingDirection = null;
+  }
+
+  const newHead = {
+    x: snake[0].x + direction.x,
+    y: snake[0].y + direction.y,
+  };
+
+  if (
+    newHead.x < 0 ||
+    newHead.x >= config.gridSize ||
+    newHead.y < 0 ||
+    newHead.y >= config.gridSize ||
+    snake.some((segment) => segment.x === newHead.x && segment.y === newHead.y)
+  ) {
+    endGame();
+    return;
+  }
+
+  snake.unshift(newHead);
+
+  const foodIndex = foods.findIndex((food) => food && food.x === newHead.x && food.y === newHead.y);
+  if (foodIndex >= 0) {
+    const food = foods.splice(foodIndex, 1)[0];
+    growth += food.type.growth;
+    addScore(food.type.score);
+    if (food.type.onEat) {
+      food.type.onEat();
+    }
+    audio.onFruit(food.type.key);
+    createParticles(newHead.x, newHead.y, food.type.particles || food.type.color);
+    createRipple(newHead.x, newHead.y, food.type.color);
+    ensureFood();
+  }
+
+  if (growth > 0) {
+    growth -= 1;
+  } else {
+    snake.pop();
+  }
+}
+
+function updateParticles(delta) {
+  particles = particles.filter((particle) => particle.life > 0);
+  particles.forEach((particle) => {
+    particle.life -= particle.decay * delta;
+    particle.x += particle.vx * delta;
+    particle.y += particle.vy * delta;
+    particle.vy += 0.00018 * delta;
+    particle.vx *= 0.995;
+    particle.vy *= 0.995;
+  });
+}
+
+function createParticles(cellX, cellY, color) {
+  const centerX = (cellX + 0.5) * config.tileSize;
+  const centerY = (cellY + 0.5) * config.tileSize;
+  for (let i = 0; i < 18; i += 1) {
+    const angle = (Math.PI * 2 * i) / 18 + Math.random() * 0.4;
+    const speed = 0.07 + Math.random() * 0.05;
+    particles.push({
+      x: centerX,
+      y: centerY,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      life: 1,
+      decay: 0.0014 + Math.random() * 0.001,
+      color,
+    });
+  }
+}
+
+function drawParticles() {
+  particles.forEach((particle) => {
+    ctx.save();
+    ctx.globalAlpha = Math.max(0, particle.life);
+    ctx.fillStyle = hexToRgba(particle.color, 0.9);
+    ctx.shadowColor = hexToRgba(particle.color, 0.8);
+    ctx.shadowBlur = 12;
+    ctx.beginPath();
+    ctx.arc(particle.x, particle.y, 3.5 * (1 - particle.life * 0.4), 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  });
+}
+
+function createRipple(cellX, cellY, color) {
+  ripples.push({
+    x: (cellX + 0.5) * config.tileSize,
+    y: (cellY + 0.5) * config.tileSize,
+    radius: config.tileSize * 0.6,
+    life: 1,
+    color,
+  });
+}
+
+function updateRipples(delta) {
+  ripples = ripples.filter((ripple) => ripple.life > 0);
+  ripples.forEach((ripple) => {
+    ripple.radius += delta * 0.08;
+    ripple.life -= delta * 0.0004;
+  });
+}
+
+function drawRipples() {
+  ripples.forEach((ripple) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.strokeStyle = hexToRgba(ripple.color, ripple.life * 0.5);
+    ctx.lineWidth = 3;
+    ctx.globalAlpha = Math.max(0, ripple.life * 0.7);
+    ctx.arc(ripple.x, ripple.y, ripple.radius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  });
+}
+
+function createFloatingText(text, color) {
+  if (floatingTexts.length > 4) {
+    floatingTexts.shift();
+  }
+  floatingTexts.push({
+    text,
+    color,
+    life: 1,
+    y: 60,
+  });
+}
+
+function updateFloatingTexts(delta) {
+  floatingTexts = floatingTexts.filter((item) => item.life > 0);
+  floatingTexts.forEach((item) => {
+    item.y -= delta * 0.03;
+    item.life -= delta * 0.0007;
+  });
+}
+
+function drawFloatingTexts() {
+  floatingTexts.forEach((item, index) => {
+    ctx.save();
+    ctx.font = "600 18px 'Poppins', 'PingFang SC', sans-serif";
+    ctx.fillStyle = hexToRgba(item.color, Math.max(0, item.life));
+    ctx.textAlign = "center";
+    ctx.fillText(item.text, canvas.width / 2, item.y + index * 26);
+    ctx.restore();
+  });
+}
+
+function drawBackground(time) {
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, "#050916");
+  gradient.addColorStop(1, "#02040b");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.save();
+  ctx.globalAlpha = 0.18;
+  ctx.fillStyle = hexToRgba("#7a5cf4", 0.35);
+  const pulse = Math.sin(time * 0.0014) * 30 + 120;
+  ctx.beginPath();
+  ctx.arc(canvas.width * 0.28, canvas.height * 0.26, pulse, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = hexToRgba("#1e9ef5", 0.28);
+  ctx.beginPath();
+  ctx.arc(canvas.width * 0.74, canvas.height * 0.75, 140 + Math.cos(time * 0.0011) * 28, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawGrid() {
+  ctx.save();
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.035)";
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= config.gridSize; i += 1) {
+    ctx.beginPath();
+    ctx.moveTo(i * config.tileSize, 0);
+    ctx.lineTo(i * config.tileSize, canvas.height);
+    ctx.stroke();
+  }
+  for (let j = 0; j <= config.gridSize; j += 1) {
+    ctx.beginPath();
+    ctx.moveTo(0, j * config.tileSize);
+    ctx.lineTo(canvas.width, j * config.tileSize);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawFoods(time) {
+  foods.forEach((food) => {
+    if (!food) return;
+    const centerX = (food.x + 0.5) * config.tileSize;
+    const centerY = (food.y + 0.5) * config.tileSize;
+    const wave = Math.sin(time * 0.003 + food.waveOffset) * 0.5;
+    const radius = config.tileSize * (0.32 + wave * 0.04);
+
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.globalAlpha = 0.85;
+    ctx.shadowColor = hexToRgba(food.type.color, 0.8);
+    ctx.shadowBlur = food.type.key === "royal" ? 32 : 20;
+    ctx.fillStyle = hexToRgba(food.type.color, 0.95);
+    ctx.beginPath();
+    ctx.arc(0, 0, radius + 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.globalCompositeOperation = "lighter";
+    ctx.fillStyle = hexToRgba(food.type.color, 0.8);
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.globalCompositeOperation = "source-over";
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.35)";
+    ctx.lineWidth = 1.6;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius * 1.45, 0, Math.PI * 2);
+    ctx.stroke();
+
+    if (food.type.key === "royal") {
+      ctx.rotate((time * 0.0012) % (Math.PI * 2));
+      ctx.strokeStyle = hexToRgba("#ffffff", 0.28);
+      ctx.lineWidth = 1.2;
+      for (let i = 0; i < 6; i += 1) {
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(0, radius * 1.9);
+        ctx.stroke();
+        ctx.rotate((Math.PI * 2) / 6);
+      }
+    }
+
+    ctx.restore();
+  });
+}
+
+function drawSnake(time) {
+  const rainbowActive = rainbowTimer > 0;
+  const headDirection = pendingDirection || direction;
+  snake.forEach((segment, index) => {
+    const t = index / Math.max(1, snake.length - 1);
+    const hue = rainbowActive ? (rainbowHue + t * 180) % 360 : 190 + t * 55;
+    const lightness = rainbowActive ? 60 + Math.cos(time * 0.003 + t * 3) * 12 : 50 + (1 - t) * 12;
+    const size = config.tileSize - 4 + Math.sin(time * 0.002 + t * 6) * 0.6;
+    const x = segment.x * config.tileSize + (config.tileSize - size) / 2;
+    const y = segment.y * config.tileSize + (config.tileSize - size) / 2;
+
+    ctx.save();
+    ctx.fillStyle = `hsl(${hue}, 90%, ${lightness}%)`;
+    ctx.shadowColor = `hsla(${hue}, 90%, ${Math.min(lightness + 18, 90)}%, 0.85)`;
+    ctx.shadowBlur = 22 - t * 12;
+    roundedRect(ctx, x, y, size, size, Math.min(size / 2, 12));
+    ctx.fill();
+
+    if (index === 0) {
+      ctx.shadowBlur = 30;
+      ctx.strokeStyle = `hsla(${hue}, 98%, 70%, 0.35)`;
+      ctx.lineWidth = 2;
+      roundedRect(ctx, x - 2, y - 2, size + 4, size + 4, Math.min(size / 2 + 2, 14));
+      ctx.stroke();
+
+      const eyeOffset = config.tileSize * 0.18;
+      const forwardOffsetX = headDirection.x * config.tileSize * 0.18;
+      const forwardOffsetY = headDirection.y * config.tileSize * 0.18;
+      const perpendicular = { x: -headDirection.y, y: headDirection.x };
+
+      const headCenterX = segment.x * config.tileSize + config.tileSize / 2;
+      const headCenterY = segment.y * config.tileSize + config.tileSize / 2;
+      const leftEyeX = headCenterX + perpendicular.x * eyeOffset + forwardOffsetX;
+      const leftEyeY = headCenterY + perpendicular.y * eyeOffset + forwardOffsetY;
+      const rightEyeX = headCenterX - perpendicular.x * eyeOffset + forwardOffsetX;
+      const rightEyeY = headCenterY - perpendicular.y * eyeOffset + forwardOffsetY;
+
+      ctx.fillStyle = "rgba(255, 255, 255, 0.92)";
+      ctx.beginPath();
+      ctx.arc(leftEyeX, leftEyeY, config.tileSize * 0.12, 0, Math.PI * 2);
+      ctx.arc(rightEyeX, rightEyeY, config.tileSize * 0.12, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "rgba(24, 30, 50, 0.85)";
+      ctx.beginPath();
+      ctx.arc(
+        leftEyeX + headDirection.x * config.tileSize * 0.08,
+        leftEyeY + headDirection.y * config.tileSize * 0.08,
+        config.tileSize * 0.05,
+        0,
+        Math.PI * 2,
+      );
+      ctx.arc(
+        rightEyeX + headDirection.x * config.tileSize * 0.08,
+        rightEyeY + headDirection.y * config.tileSize * 0.08,
+        config.tileSize * 0.05,
+        0,
+        Math.PI * 2,
+      );
+      ctx.fill();
+    }
+    ctx.restore();
+  });
+}
+
+function roundedRect(context, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.lineTo(x + width - r, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r);
+  context.lineTo(x + width, y + height - r);
+  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  context.lineTo(x + r, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r);
+  context.lineTo(x, y + r);
+  context.quadraticCurveTo(x, y, x + r, y);
+  context.closePath();
+}
+
+function draw(time) {
+  drawBackground(time);
+  drawGrid();
+  drawRipples();
+  drawFoods(time);
+  drawSnake(time);
+  drawParticles();
+  drawFloatingTexts();
+}
+
+function loop(time) {
+  const delta = time - lastFrameTime || 16;
+  lastFrameTime = time;
+
+  if (state === "running") {
+    const interval = getStepInterval();
+    if (time - lastStepTime >= interval) {
+      step();
+      lastStepTime = time;
+    }
+    slowTimer = Math.max(0, slowTimer - delta);
+    if (speedBonus > 0) {
+      speedBonus = Math.max(0, speedBonus - delta * 0.00005);
+    }
+    if (rainbowTimer > 0) {
+      rainbowTimer = Math.max(0, rainbowTimer - delta);
+      rainbowHue = (rainbowHue + delta * 0.08) % 360;
+    }
+  }
+
+  updateParticles(delta);
+  updateRipples(delta);
+  updateFloatingTexts(delta);
+  draw(time);
+
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/snake/style.css
+++ b/snake/style.css
@@ -1,0 +1,491 @@
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+:root {
+  color-scheme: dark;
+  font-family: "Poppins", "PingFang SC", "Segoe UI", system-ui, sans-serif;
+  --bg: #050911;
+  --bg-accent: rgba(12, 19, 38, 0.7);
+  --text-primary: #f5f8ff;
+  --text-dim: #9ca9ff;
+  --accent: #7a5cf4;
+  --accent-2: #1e9ef5;
+  --accent-3: #f55ce6;
+  --shadow: rgba(122, 92, 244, 0.45);
+  --shadow-strong: rgba(5, 200, 255, 0.55);
+  --card: rgba(14, 19, 41, 0.75);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, rgba(107, 70, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(255, 123, 82, 0.18), transparent 45%),
+    radial-gradient(circle at 50% 80%, rgba(74, 220, 255, 0.22), transparent 50%),
+    var(--bg);
+  overflow: hidden;
+  color: var(--text-primary);
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  width: 120vmax;
+  height: 120vmax;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.08) 0%, transparent 60%);
+  filter: blur(60px);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+body::after {
+  animation: rotate 40s linear infinite;
+  background: conic-gradient(from 90deg, rgba(122, 92, 244, 0.1), rgba(30, 158, 245, 0.18), rgba(245, 92, 230, 0.16), rgba(122, 92, 244, 0.1));
+  mix-blend-mode: screen;
+  opacity: 0.5;
+}
+
+@keyframes rotate {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+.stars {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.3) 0.5px, transparent 1px);
+  background-size: 50px 50px;
+  opacity: 0.15;
+  animation: twinkle 9s linear infinite;
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: 0.1;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+.aurora {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 20%, rgba(0, 255, 209, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 60%, rgba(255, 0, 214, 0.15), transparent 55%);
+  mix-blend-mode: screen;
+  animation: aurora 30s ease-in-out infinite alternate;
+}
+
+@keyframes aurora {
+  0% {
+    transform: translateX(-4%) scale(1.05);
+  }
+  100% {
+    transform: translateX(4%) scale(1.1);
+  }
+}
+
+.game-wrapper {
+  position: relative;
+  width: min(960px, 94vw);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border-radius: 32px;
+  background: var(--card);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 20px 60px rgba(9, 12, 28, 0.45), 0 0 35px var(--shadow);
+  backdrop-filter: blur(24px) saturate(140%);
+  z-index: 1;
+}
+
+.top-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 2rem;
+  justify-content: space-between;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: transparent;
+  background: linear-gradient(120deg, #f5f8ff, #84f5ff, #dcb7ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  text-shadow: 0 0 22px rgba(132, 245, 255, 0.45), 0 0 40px rgba(122, 92, 244, 0.35);
+}
+
+.branding p {
+  margin: 0.75rem 0 0;
+  max-width: 36rem;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.badges {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.badge {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(122, 92, 244, 0.35), rgba(30, 158, 245, 0.35));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.08);
+}
+
+.glass-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: rgba(122, 92, 244, 0.35);
+  box-shadow: 0 10px 30px rgba(8, 15, 28, 0.4), inset 0 0 25px rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  backdrop-filter: blur(16px);
+}
+
+.glass-button:hover,
+.glass-button:focus-visible {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 14px 35px rgba(8, 15, 28, 0.55), inset 0 0 25px rgba(255, 255, 255, 0.16);
+}
+
+.stats {
+  margin: clamp(1.5rem, 3vw, 2.5rem) 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat {
+  padding: 1rem 1.25rem;
+  border-radius: 24px;
+  background: rgba(10, 14, 30, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.06), 0 15px 25px rgba(4, 8, 17, 0.45);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stat.pulse {
+  animation: statPulse 0.65s ease;
+}
+
+@keyframes statPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.06), 0 15px 25px rgba(4, 8, 17, 0.45);
+  }
+  45% {
+    transform: scale(1.04);
+    box-shadow: 0 0 32px rgba(122, 92, 244, 0.6), 0 0 60px rgba(30, 158, 245, 0.35);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.06), 0 15px 25px rgba(4, 8, 17, 0.45);
+  }
+}
+
+.stat .label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.stat .value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  text-shadow: 0 0 18px rgba(122, 92, 244, 0.4);
+}
+
+.progress {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar {
+  position: absolute;
+  inset: 0;
+  width: 30%;
+  background: linear-gradient(90deg, rgba(126, 255, 255, 0.8), rgba(255, 163, 253, 0.8));
+  box-shadow: 0 0 18px rgba(126, 255, 255, 0.6);
+  transition: width 0.4s ease, transform 0.4s ease;
+  transform-origin: left;
+}
+
+.canvas-container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  border-radius: 32px;
+  background: radial-gradient(circle at top, rgba(122, 92, 244, 0.18), transparent 60%),
+    rgba(5, 9, 17, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 25px 80px rgba(8, 11, 23, 0.6);
+}
+
+.canvas-glow {
+  position: absolute;
+  inset: 2.5rem;
+  border-radius: 28px;
+  background: radial-gradient(circle, rgba(122, 92, 244, 0.15), transparent 70%);
+  filter: blur(35px);
+  z-index: 0;
+}
+
+canvas {
+  width: min(640px, 70vw);
+  aspect-ratio: 1 / 1;
+  background: radial-gradient(circle at 50% 15%, rgba(122, 92, 244, 0.15), transparent 55%),
+    radial-gradient(circle at 20% 80%, rgba(30, 158, 245, 0.15), transparent 60%),
+    linear-gradient(135deg, #060917, #05060f);
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 40px 60px rgba(6, 10, 22, 0.6), 0 0 40px rgba(122, 92, 244, 0.35);
+  position: relative;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: clamp(2rem, 6vw, 3.5rem);
+  border-radius: 26px;
+  background: rgba(6, 9, 20, 0.8);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  z-index: 2;
+  text-align: center;
+  padding: clamp(2rem, 4vw, 3rem);
+  box-shadow: 0 25px 60px rgba(6, 10, 23, 0.7);
+}
+
+.overlay.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.overlay h2 {
+  font-size: clamp(1.6rem, 3vw, 2.3rem);
+  margin: 0 0 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.overlay p {
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 1.5rem;
+}
+
+.touch-controls {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: grid;
+  place-items: center;
+  gap: 0.6rem;
+  z-index: 3;
+}
+
+.touch-controls .control {
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 12, 26, 0.65);
+  color: var(--text-primary);
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 14px 24px rgba(5, 9, 17, 0.5);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.touch-controls .control:active {
+  transform: scale(0.92);
+}
+
+.touch-controls .middle-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.info {
+  margin-top: clamp(1.5rem, 4vw, 2.8rem);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  background: rgba(10, 14, 30, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.06);
+  line-height: 1.7;
+  color: rgba(245, 248, 255, 0.8);
+}
+
+.info ul {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.info li {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.dot--berry {
+  color: #ff6b81;
+}
+
+.dot--citrus {
+  color: #ffb347;
+}
+
+.dot--mint {
+  color: #6cf9e5;
+}
+
+.dot--royal {
+  color: #c77dff;
+}
+
+.credit {
+  margin-top: 1.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 820px) {
+  .meta {
+    align-items: flex-start;
+    width: 100%;
+  }
+
+  .touch-controls {
+    position: static;
+    margin-top: 1rem;
+    justify-self: center;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .touch-controls .middle-row {
+    gap: 0.75rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .game-wrapper {
+    padding: 1.5rem;
+  }
+
+  .canvas-container {
+    padding: 1rem;
+  }
+
+  .touch-controls .control {
+    width: 2.7rem;
+    height: 2.7rem;
+    font-size: 1.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.light-mode {
+  --bg: #f6f8ff;
+  --bg-accent: rgba(255, 255, 255, 0.7);
+  --text-primary: #12203a;
+  --text-dim: #495a7d;
+  --accent: #7a5cf4;
+  --accent-2: #148bdb;
+  --accent-3: #f55ce6;
+  --shadow: rgba(122, 92, 244, 0.18);
+  --card: rgba(255, 255, 255, 0.8);
+  color-scheme: light;
+}
+
+.light-mode body {
+  background: radial-gradient(circle at 20% 20%, rgba(122, 92, 244, 0.12), transparent 55%),
+    radial-gradient(circle at 80% 30%, rgba(255, 132, 88, 0.12), transparent 50%),
+    #f6f8ff;
+}
+
+.light-mode .canvas-container {
+  background: radial-gradient(circle at top, rgba(122, 92, 244, 0.1), transparent 55%),
+    rgba(255, 255, 255, 0.9);
+}
+
+.light-mode canvas {
+  background: radial-gradient(circle at 50% 15%, rgba(122, 92, 244, 0.1), transparent 60%),
+    radial-gradient(circle at 20% 80%, rgba(30, 158, 245, 0.1), transparent 60%),
+    linear-gradient(135deg, #f3f5ff, #dfe7ff);
+}
+
+.light-mode .info {
+  background: rgba(255, 255, 255, 0.85);
+}


### PR DESCRIPTION
## Summary
- build a Neon Serpent landing page with animated chrome, responsive stats, and overlay instructions
- implement the canvas-powered snake game with special fruit effects, particles, audio cues, and high-score persistence
- add touch and swipe controls plus theme toggling with reduced-motion support for accessibility

## Testing
- node --check snake/main.js

------
https://chatgpt.com/codex/tasks/task_e_68d013530dfc832eb0e66e19ac978cf8